### PR TITLE
feat(owner & property): add uniqueness validation and pagination sorted by latest entries

### DIFF
--- a/backend/src/main/java/BackEnd/Rentary/Common/Address.java
+++ b/backend/src/main/java/BackEnd/Rentary/Common/Address.java
@@ -1,15 +1,13 @@
 package BackEnd.Rentary.Common;
 
 import jakarta.persistence.Embeddable;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 @Getter
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
+@EqualsAndHashCode
 @Embeddable
 public class Address {
     private String country;

--- a/backend/src/main/java/BackEnd/Rentary/Exceptions/ErrorResponse.java
+++ b/backend/src/main/java/BackEnd/Rentary/Exceptions/ErrorResponse.java
@@ -1,6 +1,8 @@
 package BackEnd.Rentary.Exceptions;
 
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.util.List;
 

--- a/backend/src/main/java/BackEnd/Rentary/Owners/Controller/OwnerController.java
+++ b/backend/src/main/java/BackEnd/Rentary/Owners/Controller/OwnerController.java
@@ -2,24 +2,28 @@ package BackEnd.Rentary.Owners.Controller;
 
 import BackEnd.Rentary.Owners.DTOs.OwnerDto;
 import BackEnd.Rentary.Owners.Services.OwnerServiceImpl;
+import BackEnd.Rentary.Propertys.DTOs.CustomPageResponse;
 import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/owner")
+@RequiredArgsConstructor
 public class OwnerController {
 
-    private OwnerServiceImpl ownerService;
+    private final OwnerServiceImpl ownerService;
 
-    public OwnerController(OwnerServiceImpl ownerService) {
-        this.ownerService = ownerService;
-    }
+    @GetMapping
+    public ResponseEntity<CustomPageResponse<OwnerDto>> getOwners(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
 
-    @GetMapping("/")
-    public ResponseEntity<?> getOwner(){
-
-        return ResponseEntity.ok(ownerService.getOwner());
+        Pageable pageable = PageRequest.of(page, size);
+        return ResponseEntity.ok(ownerService.getOwner(pageable));
     }
 
     @GetMapping("/{id}")
@@ -34,13 +38,13 @@ public class OwnerController {
         return ownerService.createOwner(ownerDto);
     }
 
-    @DeleteMapping("/delete")
+    @DeleteMapping("/delete/{id}")
     public ResponseEntity<?> deleteOwner(@PathVariable Long id){
 
         return ownerService.deleteOwner(id);
     }
 
-    @PutMapping("/update")
+    @PutMapping("/update/{id}")
     public ResponseEntity<?> updateOwner(@PathVariable Long id, @RequestBody @Valid OwnerDto ownerDto){
 
         return ownerService.updateOwner(id, ownerDto );

--- a/backend/src/main/java/BackEnd/Rentary/Owners/DTOs/OwnerDto.java
+++ b/backend/src/main/java/BackEnd/Rentary/Owners/DTOs/OwnerDto.java
@@ -1,10 +1,11 @@
 package BackEnd.Rentary.Owners.DTOs;
 
-
 import BackEnd.Rentary.Common.Address;
-import BackEnd.Rentary.Propertys.Entities.Property;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,12 +16,21 @@ import lombok.Setter;
 @AllArgsConstructor
 @NoArgsConstructor
 public class OwnerDto {
-
+    @NotNull(message = "Este campo es necesario.")
     private String name;
+    @NotNull(message = "Este campo es necesario.")
     private String lastName;
+    @NotBlank(message = "El DNI es obligatorio")
+    @Pattern(regexp = "\\d{8}", message = "El DNI debe tener 8 dígitos numéricos")
     private String dni;
+    @Email(message = "El email debe ser válido.")
+    @NotNull(message = "Este campo es necesario.")
     private String email;
+    @NotNull(message = "Este campo es necesario.")
     private String phone;
     @Valid
+    @NotNull(message = "Este campo es necesario.")
     private Address address;
+
+    private String attachedDocument;
 }

--- a/backend/src/main/java/BackEnd/Rentary/Owners/Entities/Owner.java
+++ b/backend/src/main/java/BackEnd/Rentary/Owners/Entities/Owner.java
@@ -3,7 +3,10 @@ package BackEnd.Rentary.Owners.Entities;
 import BackEnd.Rentary.Common.Person;
 import BackEnd.Rentary.Propertys.Entities.Property;
 import jakarta.persistence.*;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -12,14 +15,14 @@ import java.util.List;
 @Table(name = "owners")
 @Getter
 @Setter
-@Data
 @AllArgsConstructor
 @NoArgsConstructor
 public class Owner extends Person {
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @OneToMany(mappedBy = "owner", cascade = CascadeType.ALL)
     private List<Property> properties= new ArrayList<>();
+    @Column(name = "attached_document")
+    private String attachedDocument;
 }

--- a/backend/src/main/java/BackEnd/Rentary/Owners/Repositories/OwnerRepository.java
+++ b/backend/src/main/java/BackEnd/Rentary/Owners/Repositories/OwnerRepository.java
@@ -6,4 +6,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface OwnerRepository extends JpaRepository<Owner, Long> {
+    boolean existsByDni(String dni);
 }

--- a/backend/src/main/java/BackEnd/Rentary/Owners/Services/OwnerService.java
+++ b/backend/src/main/java/BackEnd/Rentary/Owners/Services/OwnerService.java
@@ -1,17 +1,14 @@
 package BackEnd.Rentary.Owners.Services;
 
 import BackEnd.Rentary.Owners.DTOs.OwnerDto;
+import BackEnd.Rentary.Propertys.DTOs.CustomPageResponse;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 
-import java.util.List;
-import java.util.Optional;
-
 public interface OwnerService {
-
-    public List<OwnerDto> getOwner();
-    public ResponseEntity<?> getOwnerId(Long id);
-    public ResponseEntity<?> createOwner(OwnerDto owner);
-    public ResponseEntity<?> deleteOwner(Long id);
-    public ResponseEntity<?> updateOwner(Long id, OwnerDto owner);
-
+    ResponseEntity<?> getOwnerId(Long id);
+    ResponseEntity<?> createOwner(OwnerDto owner);
+    ResponseEntity<?> deleteOwner(Long id);
+    ResponseEntity<?> updateOwner(Long id, OwnerDto owner);
+    CustomPageResponse<OwnerDto> getOwner(Pageable pageable);
 }

--- a/backend/src/main/java/BackEnd/Rentary/Propertys/Controller/PropertyController.java
+++ b/backend/src/main/java/BackEnd/Rentary/Propertys/Controller/PropertyController.java
@@ -65,4 +65,14 @@ public class PropertyController {
 
         return ResponseEntity.ok(response);
     }
+
+    @PatchMapping("/update/{id}")
+    public ResponseEntity<PropertyResponseDto> updateProperty(
+            @PathVariable Long id,
+            @RequestBody @Valid PropertyRequestDto dto) {
+
+        PropertyResponseDto updatedProperty = propertyService.updateProperty(id, dto);
+        return ResponseEntity.ok(updatedProperty);
+    }
+
 }

--- a/backend/src/main/java/BackEnd/Rentary/Propertys/DTOs/PropertyRequestDto.java
+++ b/backend/src/main/java/BackEnd/Rentary/Propertys/DTOs/PropertyRequestDto.java
@@ -1,15 +1,15 @@
 package BackEnd.Rentary.Propertys.DTOs;
 
+import BackEnd.Rentary.Common.Address;
 import BackEnd.Rentary.Propertys.Enums.TypeOfProperty;
+import jakarta.validation.constraints.NotNull;
 
 public record PropertyRequestDto(
-        String country,
-        String province,
-        String locality,
-        String street,
-        String number,
-        String postalCode,
+        @NotNull(message = "Este campo es necesario.")
+        Address address,
+        @NotNull(message = "Este campo es necesario.")
         TypeOfProperty typeOfProperty,
         String observations,
+        @NotNull(message = "Este campo es necesario.")
         Long ownerId
 ) {}

--- a/backend/src/main/java/BackEnd/Rentary/Propertys/Enums/PropertyStatus.java
+++ b/backend/src/main/java/BackEnd/Rentary/Propertys/Enums/PropertyStatus.java
@@ -1,7 +1,7 @@
 package BackEnd.Rentary.Propertys.Enums;
 
 public enum PropertyStatus {
-    ALQUILADO,
-    NO_ALQUILADO,
+    OCUPADO,
+    DISPONIBLE,
     NO_DISPONIBLE
 }

--- a/backend/src/main/java/BackEnd/Rentary/Propertys/Mapper/PropertyMapper.java
+++ b/backend/src/main/java/BackEnd/Rentary/Propertys/Mapper/PropertyMapper.java
@@ -28,19 +28,11 @@ public class PropertyMapper {
     }
 
     public Property toEntity(PropertyRequestDto dto, Owner owner) {
-        Address address = new Address(
-                dto.country(),
-                dto.province(),
-                dto.locality(),
-                dto.street(),
-                dto.number(),
-                dto.postalCode()
-        );
 
         Property property = new Property();
-        property.setAddress(address);
+        property.setAddress(dto.address());
         property.setTypeOfProperty(dto.typeOfProperty());
-        property.setStatus(PropertyStatus.NO_ALQUILADO);
+        property.setStatus(PropertyStatus.DISPONIBLE);
         property.setObservations(dto.observations());
         property.setOwner(owner);
 

--- a/backend/src/main/java/BackEnd/Rentary/Propertys/Repositoy/PropertyRepository.java
+++ b/backend/src/main/java/BackEnd/Rentary/Propertys/Repositoy/PropertyRepository.java
@@ -1,5 +1,6 @@
 package BackEnd.Rentary.Propertys.Repositoy;
 
+import BackEnd.Rentary.Common.Address;
 import BackEnd.Rentary.Propertys.Entities.Property;
 import BackEnd.Rentary.Propertys.Enums.TypeOfProperty;
 import org.springframework.data.domain.Page;
@@ -11,7 +12,6 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PropertyRepository extends JpaRepository<Property, Long> {
-
     @Query("""
     SELECT p FROM Property p
     WHERE p.status = 'NO_ALQUILADO'
@@ -23,4 +23,5 @@ public interface PropertyRepository extends JpaRepository<Property, Long> {
             @Param("type") TypeOfProperty type,
             Pageable pageable
     );
+    boolean existsByAddress(Address address);
 }

--- a/backend/src/main/java/BackEnd/Rentary/Propertys/Service/IPropertyService.java
+++ b/backend/src/main/java/BackEnd/Rentary/Propertys/Service/IPropertyService.java
@@ -12,5 +12,5 @@ public interface IPropertyService {
     PropertyResponseDto changePropertyStatus (Long propertyId, PropertyStatus newStatus);
     void deleteProperty(Long id);
     Page<PropertyResponseDto> getAllActivePropertiesFiltered(String locality, TypeOfProperty type, Pageable pageable);
-
+    PropertyResponseDto updateProperty(Long propertyId, PropertyRequestDto dto);
 }

--- a/backend/src/main/java/BackEnd/Rentary/Tenants/DTOs/TenantsRequestDto.java
+++ b/backend/src/main/java/BackEnd/Rentary/Tenants/DTOs/TenantsRequestDto.java
@@ -5,7 +5,6 @@ import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.springframework.web.multipart.MultipartFile;
 
 @Data
 @NoArgsConstructor


### PR DESCRIPTION
Changes Introduced:

    Unique DNI validation for Owner:

      Allows editing with the same DNI as the original without error.

      Prevents creating or updating an Owner with a DNI that belongs to another Owner.

    Unique address validation for Property:

      Blocks creation or update if another Property already exists with the exact same address (country, province, locality, street, number, postalCode).

      Allows saving if the address remains the same for the current property being edited.

    Edit restriction for NO_DISPONIBLE properties:

        Returns HTTP 400 if attempting to update a property marked as unavailable.

    Property update method (updateProperty):

        Updates the property after all validations pass.

    Pagination for Owners:

        Implements pagination for listing Owners.

        Sorted by latest (descending ID).

        Returns data wrapped in a CustomPageResponse<OwnerDto> including content, totalPages, totalElements, currentPage.